### PR TITLE
pin proc-macro2 for packaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 name = "madato"
 version = "0.5.1"
 authors = ["Ramon Buckland <ramon.buckland@inosion.com>"]
+license = "MIT/Apache-2.0"
+description = "A library and command line tool for working tabular data (XLS, ODS, CSV, YAML), and Markdown"
+readme  = "README.md"
+keywords = ["markdown","excel","yaml","tables","openoffice"]
 exclude = [
     "doc/*",
     "assets/*",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde_yaml      = "0.7.5"
 indexmap        = "1.0.1"
 docopt          = "1.0.0"
 calamine        = "0.14"
+proc-macro2     = "=0.4.8"
 
 [dependencies.linked-hash-map]
 version = "0.5.1"


### PR DESCRIPTION
pin proc-macro2 as `cargo package` pulled in a separate version (v0.4.11) which did not compile 

[https://github.com/alexcrichton/proc-macro2/issues/113](https://github.com/alexcrichton/proc-macro2/issues/113)